### PR TITLE
Enhance C-Style Makefile build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 *.a
 .deps
 .libs
+src
+verm

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,20 @@
+PREFIX    = /usr/local
+BINDIR    = $(PREFIX)/bin
+
 default: verm
 
 install: verm
-	install $^ /usr/local/bin
-	mkdir -p /var/lib/verm
+	install -d $(DESTDIR)$(BINDIR)/
+	install $^ $(DESTDIR)$(BINDIR)
+	mkdir -p $(DESTDIR)/var/lib/verm
 
 verm: *.go */*.go
-	GOPATH=`pwd`/../.. go build
+	mkdir -p src/github.com/willbryant
+	( cd src/github.com/willbryant && ln -sf ../../../ verm)
+	GOPATH="`pwd`" go build
 
 clean:
-	rm -f verm
+	rm -rf verm src
 
 test_verm: verm
 	BUNDLE_GEMFILE=test/Gemfile bundle exec testrb test/get_files_test.rb test/create_files_multipart_test.rb test/create_files_raw_test.rb test/health_check_test.rb test/replication_put_test.rb test/replication_missing_test.rb test/replication_propagation_test.rb test/replication_topology_test.rb test/read_forwarding_test.rb


### PR DESCRIPTION
Support DESTDIR and PREFIX in Makefile.

Fix building with Makefile. Currently this is failing with:
```
GOPATH=`pwd`/../.. go build
file_uploader.go:16:8: cannot find package "github.com/willbryant/verm/mimeext" in any of:
        /usr/lib64/go1.6.2/go/src/github.com/willbryant/verm/mimeext (from $GOROOT)
        /src/github.com/willbryant/verm/mimeext (from $GOPATH)
Makefile:8: recipe for target 'verm' failed
make: *** [verm] Error 1
```