### PR TITLE
Fix tests

### DIFF
--- a/test/replication_propagation_test.rb
+++ b/test/replication_propagation_test.rb
@@ -140,7 +140,8 @@ class ReplicationPropagationTest < Verm::TestCase
     }, changes)
 
     unless ENV['VALGRIND'] || ENV['NO_CAPTURE_STDERR'].to_i > 0
-      assert File.read(REPLICATION_MASTER_VERM_SPAWNER.capture_stderr_in).downcase.include?("#{VERM_SPAWNER.port}: connection refused"),
+      assert_match /#{VERM_SPAWNER.port}:( getsockopt:)? connection refused/,
+        File.read(REPLICATION_MASTER_VERM_SPAWNER.capture_stderr_in).downcase,
         "replication error was not logged"
     end
 

--- a/test/verm_spawner.rb
+++ b/test/verm_spawner.rb
@@ -51,7 +51,7 @@ class VermSpawner
   end
   
   def start_verm(extra_options = {})
-    exec_args  = [@verm_binary, "--data", verm_data, "--port", port.to_s]
+    exec_args  = [@verm_binary, "--data", verm_data, "--port", port.to_s, "--listen", "localhost"]
     exec_args << "--quiet" unless ENV['NOISY'] || extra_options.delete(:no_quiet)
 
     @options.merge(extra_options).each do |name, value|


### PR DESCRIPTION
Couple of minor fixes so that the test suite doesn't complain so much as in #11 

First, bind to localhost only in tests so that OSX firewall wont ask about allowing verm for each test.

Second, update a test to match the error message returned by newer versions of go.