### PR TITLE
Update test suite to use minitest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,4 +17,4 @@ clean:
 	rm -rf verm src
 
 test_verm: verm
-	BUNDLE_GEMFILE=test/Gemfile bundle exec testrb test/get_files_test.rb test/create_files_multipart_test.rb test/create_files_raw_test.rb test/health_check_test.rb test/replication_put_test.rb test/replication_missing_test.rb test/replication_propagation_test.rb test/replication_topology_test.rb test/read_forwarding_test.rb
+	BUNDLE_GEMFILE=test/Gemfile bundle exec rake -f test/Rakefile test

--- a/test/Gemfile
+++ b/test/Gemfile
@@ -1,4 +1,5 @@
 source 'https://rubygems.org'
 
-gem "minitest", "~> 4.0"
+gem "minitest", "~> 5.10"
 gem "byebug"
+gem "rake"

--- a/test/Gemfile.lock
+++ b/test/Gemfile.lock
@@ -1,18 +1,17 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    byebug (3.4.0)
-      columnize (~> 0.8)
-      debugger-linecache (~> 1.2)
-      slop (~> 3.6)
-    columnize (0.8.9)
-    debugger-linecache (1.2.0)
-    minitest (4.3.2)
-    slop (3.6.0)
+    byebug (9.0.6)
+    minitest (5.10.1)
+    rake (12.0.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   byebug
-  minitest (~> 4.0)
+  minitest (~> 5.10)
+  rake
+
+BUNDLED WITH
+   1.13.6

--- a/test/Rakefile
+++ b/test/Rakefile
@@ -1,0 +1,5 @@
+require 'rake/testtask'
+
+Rake::TestTask.new do |t|
+  t.pattern = "test/*_test.rb"
+end

--- a/test/create_files_raw_test.rb
+++ b/test/create_files_raw_test.rb
@@ -24,7 +24,7 @@ class CreateFilesRawTest < Verm::TestCase
 
   def test_saves_same_gzipped_file_compressed_differently_to_same_path
     recompressed = gzip(fixture_file_data('simple_text_file'))
-    assert_not_equal recompressed, fixture_file_data('simple_text_file.gz')
+    refute_equal recompressed, fixture_file_data('simple_text_file.gz')
 
     location1 =
       post_file :path => '/foo',

--- a/test/create_files_tests.rb
+++ b/test/create_files_tests.rb
@@ -111,7 +111,7 @@ module CreateFilesSharedTests
                   :type => 'application/octet-stream',
                   :expected_extension => nil)
       
-      assert_not_equal first_file_location, different_file_location
+      refute_equal first_file_location, different_file_location
     end
   end
 

--- a/test/get_files_test.rb
+++ b/test/get_files_test.rb
@@ -74,7 +74,7 @@ class GetFilesTest < Verm::TestCase
     assert_statistics_change(:get_requests => 2) do
       copy_arbitrary_file_to('somefiles', nil)
       response = get :path => @location
-      assert_not_nil response['etag']
+      refute_nil response['etag']
       
       get :path => @location,
           :headers => {'if-none-match' => response['etag']},

--- a/test/net_http_multipart_post.rb
+++ b/test/net_http_multipart_post.rb
@@ -9,6 +9,7 @@ module Net
       def initialize(*args)
         super(*args)
 
+        @added_final_boundary = nil
         chrs = "0123456789abcdefghijklmnopqrstuvwxyz"
         random_str = (0..11).collect { chrs[rand(36)] }.join
         @boundary = ".multipart_boundary_#{random_str}.".freeze

--- a/test/replication_missing_test.rb
+++ b/test/replication_missing_test.rb
@@ -11,7 +11,7 @@ class ReplicationMissingTest < Verm::TestCase
   end
 
   def assert_ungzipped_body(content, response)
-    assert_equal nil, response['content-encoding']
+    assert_nil response['content-encoding']
     assert_equal content, response.body
   end
 

--- a/test/replication_propagation_test.rb
+++ b/test/replication_propagation_test.rb
@@ -140,9 +140,9 @@ class ReplicationPropagationTest < Verm::TestCase
     }, changes)
 
     unless ENV['VALGRIND'] || ENV['NO_CAPTURE_STDERR'].to_i > 0
-      assert_match /#{VERM_SPAWNER.port}:( getsockopt:)? connection refused/,
+      assert_match(/#{VERM_SPAWNER.port}:( getsockopt:)? connection refused/,
         File.read(REPLICATION_MASTER_VERM_SPAWNER.capture_stderr_in).downcase,
-        "replication error was not logged"
+        "replication error was not logged")
     end
 
     VERM_SPAWNER.start_verm

--- a/test/verm_spawner.rb
+++ b/test/verm_spawner.rb
@@ -76,7 +76,7 @@ class VermSpawner
         puts e
         exit 1
       end
-      exec *exec_args
+      exec(*exec_args)
     end
   end
   


### PR DESCRIPTION
testrb doesn't seem to be bundled with ruby anymore. So to support
modern ruby the test runner needed to be changed.

This should resolve #11 
