### PR TITLE
Use expvar instead of manual atomics for statistics

### DIFF
--- a/replication_target.go
+++ b/replication_target.go
@@ -36,7 +36,7 @@ func (target *ReplicationTarget) Start(rootDataDirectory string, statistics *Log
 			Timeout:   ReplicationNetworkTimeout * time.Second,
 			KeepAlive: ReplicationNetworkTimeout * time.Second,
 		}).Dial,
-		TLSHandshakeTimeout: ReplicationNetworkTimeout * time.Second,
+		TLSHandshakeTimeout:   ReplicationNetworkTimeout * time.Second,
 		ResponseHeaderTimeout: ReplicationNetworkTimeout * time.Second,
 	}
 
@@ -107,11 +107,11 @@ func (target *ReplicationTarget) replicateFile(location string) {
 		ok := Put(target.client, target.hostname, target.port, location, target.rootDataDirectory)
 
 		if ok {
-			atomic.AddUint64(&target.statistics.replication_push_attempts, 1)
+			target.statistics.ReplicationPushAttempts.Add(1)
 			break
 		} else {
-			atomic.AddUint64(&target.statistics.replication_push_attempts, 1)
-			atomic.AddUint64(&target.statistics.replication_push_attempts_failed, 1)
+			target.statistics.ReplicationPushAttempts.Add(1)
+			target.statistics.ReplicationPushAttemptsFailed.Add(1)
 			time.Sleep(backoffTime(attempts))
 		}
 	}

--- a/verm.go
+++ b/verm.go
@@ -58,7 +58,7 @@ func main() {
 
 	mimeext.LoadMimeFile(mimeTypesFile, mimeTypesClear)
 
-	listener, err := net.Listen("tcp", listenAddress + ":" + port)
+	listener, err := net.Listen("tcp", listenAddress+":"+port)
 
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Couldn't listen on %s:%s: %s\n", listenAddress, port, err.Error())
@@ -67,7 +67,7 @@ func main() {
 		fmt.Fprintf(os.Stdout, "%s listening on http://%s:%s, data in %s\n", banner(), listenAddress, port, rootDataDirectory)
 	}
 
-	statistics := &LogStatistics{}
+	statistics := NewLogStatistics()
 	server := VermServer(listener, rootDataDirectory, &replicationTargets, statistics, quiet)
 	replicationTargets.Start(rootDataDirectory, statistics, replicationWorkers)
 	replicationTargets.EnqueueResync()


### PR DESCRIPTION
serveStatistics has a benign data race that trips the go race detector during tests. The expvar library is designed to handle statistics like these and handles locking/atomics correctly.

This should maintain compat with the original `/_statistics` endpoint, but additionally provides a JSON endpoint under `/debug/vars` handled by the expvar lib. This may not be desirable, but the format of the endpoint is already handled by projects like prometheus and it provides a few extra stats about go memory usage.

There was some minor reformatting that happened here from `go fmt`. I can try revert those if it's an issue.