### PR TITLE
Support Prometheus formatted metrics

### DIFF
--- a/log_statistics.go
+++ b/log_statistics.go
@@ -7,38 +7,132 @@ import (
 )
 
 type LogStatistics struct {
-	GetRequests, GetRequestsFoundOnReplica, GetRequestsNotFound                            *expvar.Int
-	PostRequests, PostRequestsNewFileStored, PostRequestsFailed                            *expvar.Int
-	PutRequests, PutRequestsNewFileStored, PutRequestsMissingFileChecks, PutRequestsFailed *expvar.Int
-	ReplicationPushAttempts, ReplicationPushAttemptsFailed                                 *expvar.Int
-	ConnectionsCurrent                                                                     *expvar.Int
+	GetRequests, GetRequestsFoundOnReplica, GetRequestsNotFound                            PrometheusMetric
+	PostRequests, PostRequestsNewFileStored, PostRequestsFailed                            PrometheusMetric
+	PutRequests, PutRequestsNewFileStored, PutRequestsMissingFileChecks, PutRequestsFailed PrometheusMetric
+	ReplicationPushAttempts, ReplicationPushAttemptsFailed                                 PrometheusMetric
+	ConnectionsCurrent                                                                     PrometheusMetric
 }
 
 func NewLogStatistics() *LogStatistics {
 	return &LogStatistics{
-		GetRequests:                   expvar.NewInt("get_requests"),
-		GetRequestsFoundOnReplica:     expvar.NewInt("get_requests_found_on_replica"),
-		GetRequestsNotFound:           expvar.NewInt("get_requests_not_found"),
-		PostRequests:                  expvar.NewInt("post_requests"),
-		PostRequestsNewFileStored:     expvar.NewInt("post_requests_new_file_stored"),
-		PostRequestsFailed:            expvar.NewInt("post_requests_failed"),
-		PutRequests:                   expvar.NewInt("put_requests"),
-		PutRequestsNewFileStored:      expvar.NewInt("put_requests_new_file_stored"),
-		PutRequestsMissingFileChecks:  expvar.NewInt("put_requests_missing_file_checks"),
-		PutRequestsFailed:             expvar.NewInt("put_requests_failed"),
-		ReplicationPushAttempts:       expvar.NewInt("replication_push_attempts"),
-		ReplicationPushAttemptsFailed: expvar.NewInt("replication_push_attempts_failed"),
-		ConnectionsCurrent:            expvar.NewInt("connections_current"),
+		GetRequests: NewPrometheusMetric(&promMetricOptions{
+			name: "verm_get_requests_total",
+			metricType: "counter",
+			description: "GET requests served",
+		}),
+		GetRequestsFoundOnReplica: NewPrometheusMetric(&promMetricOptions{
+			name: "verm_get_requests_found_on_replica_total",
+			metricType: "counter",
+			description: "GET requests found on replica",
+		}),
+		GetRequestsNotFound: NewPrometheusMetric(&promMetricOptions{
+			name: "verm_get_requests_not_found_total",
+			metricType: "counter",
+			description: "GET requests not found",
+		}),
+		PostRequests: NewPrometheusMetric(&promMetricOptions{
+			name: "verm_post_requests_total",
+			metricType: "counter",
+			description: "POST requests served",
+		}),
+		PostRequestsNewFileStored: NewPrometheusMetric(&promMetricOptions{
+			name: "verm_post_requests_new_file_stored_total",
+			metricType: "counter",
+			description: "POST requests resulting in a new file stored",
+		}),
+		PostRequestsFailed: NewPrometheusMetric(&promMetricOptions{
+			name: "verm_post_requests_failed_total",
+			metricType: "counter",
+			description: "POST requests failed",
+		}),
+		PutRequests: NewPrometheusMetric(&promMetricOptions{
+			name: "verm_put_requests_total",
+			metricType: "counter",
+			description: "PUT requests served",
+		}),
+		PutRequestsNewFileStored: NewPrometheusMetric(&promMetricOptions{
+			name: "verm_put_requests_new_file_stored_total",
+			metricType: "counter",
+			description: "PUT requests resulting in a new file stored",
+		}),
+		PutRequestsMissingFileChecks: NewPrometheusMetric(&promMetricOptions{
+			name: "verm_put_requests_missing_file_checks_total",
+			metricType: "counter",
+			description: "PUT requests checking for missing files",
+		}),
+		PutRequestsFailed: NewPrometheusMetric(&promMetricOptions{
+			name: "verm_put_requests_failed_total",
+			metricType: "counter",
+			description: "PUT requests failed",
+		}),
+		ReplicationPushAttempts: NewPrometheusMetric(&promMetricOptions{
+			name: "verm_replication_push_attempts_total",
+			metricType: "counter",
+			description: "Replication push attempts",
+		}),
+		ReplicationPushAttemptsFailed: NewPrometheusMetric(&promMetricOptions{
+			name: "verm_replication_push_attempts_failed_total",
+			metricType: "counter",
+			description: "Replication push attempts failed",
+		}),
+		ConnectionsCurrent: NewPrometheusMetric(&promMetricOptions{
+			name: "verm_connections_current",
+			metricType: "gauge",
+			description: "HTTP connections",
+		}),
 	}
 }
 
 func (server vermServer) serveStatistics(w http.ResponseWriter, req *http.Request, replicationTargets *ReplicationTargets) {
 	w.WriteHeader(http.StatusOK)
-	expvar.Do(func(kv expvar.KeyValue) {
-		switch v := kv.Value.(type) {
-		case *expvar.Int:
-			fmt.Fprintf(w, "%s %d\n", kv.Key, v.Value())
-		}
-	})
+	server.Statistics.GetRequests.PrintStatistics(w)
+	server.Statistics.GetRequestsFoundOnReplica.PrintStatistics(w)
+	server.Statistics.GetRequestsNotFound.PrintStatistics(w)
+	server.Statistics.PostRequests.PrintStatistics(w)
+	server.Statistics.PostRequestsNewFileStored.PrintStatistics(w)
+	server.Statistics.PostRequestsFailed.PrintStatistics(w)
+	server.Statistics.PutRequests.PrintStatistics(w)
+	server.Statistics.PutRequestsNewFileStored.PrintStatistics(w)
+	server.Statistics.PutRequestsMissingFileChecks.PrintStatistics(w)
+	server.Statistics.PutRequestsFailed.PrintStatistics(w)
+	server.Statistics.ReplicationPushAttempts.PrintStatistics(w)
+	server.Statistics.ReplicationPushAttemptsFailed.PrintStatistics(w)
+	server.Statistics.ConnectionsCurrent.PrintStatistics(w)
 	fmt.Fprintf(w, "%s", replicationTargets.StatisticsString())
+}
+
+type PrometheusMetric interface {
+	Add(int64)
+	Value() int64
+	PrintStatistics(w http.ResponseWriter)
+}
+
+type promMetricOptions struct {
+	name 		string
+	metricType 	string
+	description string
+}
+
+type promMetric struct {
+	metric		*expvar.Int
+	options		*promMetricOptions
+}
+
+func NewPrometheusMetric(options *promMetricOptions) PrometheusMetric {
+	return &promMetric{metric: expvar.NewInt(options.name), options: options}
+}
+
+func (pi *promMetric) PrintStatistics(w http.ResponseWriter) {
+	fmt.Fprintf(w, "# HELP %s %s\n", pi.options.name, pi.options.description)
+	fmt.Fprintf(w, "# TYPE %s %s\n", pi.options.name, pi.options.metricType)
+	fmt.Fprintf(w, "%s %d\n", pi.options.name, pi.metric.Value())
+}
+
+func (pi *promMetric) Value() int64 {
+	return pi.metric.Value()
+}
+
+func (pi *promMetric) Add(val int64) {
+	pi.metric.Add(val)
 }

--- a/munin/verm_connections
+++ b/munin/verm_connections
@@ -27,7 +27,7 @@ if [ "$1" = "autoconf" ]; then
 	fi
 fi
 
-data=`echo -e "GET /_statistics HTTP/1.0\n" | nc localhost 3404 | grep connections_current`
+data=`echo -e "GET /_statistics HTTP/1.0\n" | nc localhost 3404 | grep connections_current | grep -v "#" | sed -E 's/verm_//g'`
 
 if [ "$1" = "config" ]; then
 	echo 'graph_title Verm connections'

--- a/munin/verm_replication_queue
+++ b/munin/verm_replication_queue
@@ -27,7 +27,8 @@ if [ "$1" = "autoconf" ]; then
 	fi
 fi
 
-data=`echo -e "GET /_statistics HTTP/1.0\n" | nc localhost 3404 | grep queue_length`
+data=`echo -e "GET /_statistics HTTP/1.0\n" | nc localhost 3404 | grep queue_length | grep -v "#"`
+data=`echo "$data" | sed -E 's/verm_replication_queue_length\{target="(.*):([0-9]+)"\}/replication_\1_\2_queue_length/g'`
 
 if [ "$1" = "config" ]; then
 	echo 'graph_title Verm replication queue length'

--- a/munin/verm_requests
+++ b/munin/verm_requests
@@ -27,7 +27,7 @@ if [ "$1" = "autoconf" ]; then
 	fi
 fi
 
-data=`echo -e "GET /_statistics HTTP/1.0\n" | nc localhost 3404 | grep _ | grep -v connections_current | grep -v queue_length`
+data=`echo -e "GET /_statistics HTTP/1.0\n" | nc localhost 3404 | grep _ | grep -v connections_current | grep -v queue_length | grep -v "#" | sed -E 's/verm_|_total//g'`
 
 if [ "$1" = "config" ]; then
 	echo 'graph_title Verm requests'

--- a/replication_targets.go
+++ b/replication_targets.go
@@ -54,11 +54,16 @@ func (targets *ReplicationTargets) EnqueueResync() {
 }
 
 func (targets *ReplicationTargets) StatisticsString() string {
-	result := ""
+	if len(targets.targets) <= 0 {
+		return ""
+	}
+	metricName := "verm_replication_queue_length"
+	result := fmt.Sprintf("# HELP %s Number of files in the queue to be replicated to each configured replica.\n", metricName)
+	result = fmt.Sprintf("%s# TYPE %s gauge\n", result, metricName)
 	for _, target := range targets.targets {
 		result = fmt.Sprintf(
-			"%sreplication_%s_%s_queue_length %d\n",
-			result,
+			"%s%s{target=\"%s:%s\"} %d\n",
+			result, metricName,
 			target.hostname, target.port, target.queueLength())
 	}
 	return result


### PR DESCRIPTION
- The statistics endpoint now serves Prometheus formatted metrics so
  Prometheus can scrape it directly

- Munin plugins have been changed so they continue to serve munin
  formatted metrics

- Test framework changed slightly so that all tests continue passing
  with the new statistics format